### PR TITLE
Explicitly test all arguments in the constructor to fix problems when…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,25 @@
 /*
-Copyright (c) 2014, Matteo Collina <hello@matteocollina.com>
+ Copyright (c) 2014, Matteo Collina <hello@matteocollina.com>
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-*/
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 
 'use strict';
 
 var through = require('through2')
 
 function transform(chunk, enc, cb) {
-  var list = chunk.toString('utf8').split(this.matcher)
+  var list      = chunk.toString('utf8').split(this.matcher)
     , remaining = list.pop()
     , i
 
@@ -56,26 +56,48 @@ function noop(incoming) {
 
 function split(matcher, mapper, options) {
 
-  if (typeof matcher === 'object' && !(matcher instanceof RegExp)) {
-    options = matcher
-    matcher = null
+  // Set defaults for any arguments not supplied.
+  matcher = matcher || /\r?\n/;
+  mapper = mapper || noop;
+  options = options || {};
+
+  // Test arguments explicitly.
+  switch (arguments.length) {
+    case 1:
+      // If mapper is only argument.
+      if (typeof matcher === 'function') {
+        mapper = matcher;
+        matcher = /\r?\n/;
+      }
+      // If options is only argument.
+      else if (typeof matcher === 'object' && !(matcher instanceof RegExp)) {
+        options = matcher;
+        matcher = /\r?\n/;
+      }
+      break;
+
+    case 2:
+      // If mapper and options are arguments.
+      if (typeof matcher === 'function') {
+        options = mapper;
+        mapper = matcher;
+        matcher = /\r?\n/;
+      }
+      // If matcher and options are arguments.
+      else if (typeof mapper === 'object') {
+        options = mapper;
+        mapper = noop;
+      }
   }
 
-  if (typeof matcher === 'function') {
-    mapper = matcher
-    matcher = null
-  }
-
-  options = options || {}
-
-  var stream = through(options, transform, flush)
+  var stream = through(options, transform, flush);
 
   // this stream is in objectMode only in the readable part
   stream._readableState.objectMode = true;
 
-  stream._last = ''
-  stream.matcher = matcher || /\r?\n/
-  stream.mapper = mapper || noop
+  stream._last = '';
+  stream.matcher = matcher;
+  stream.mapper = mapper;
 
   return stream
 }

--- a/index.js
+++ b/index.js
@@ -1,25 +1,25 @@
 /*
- Copyright (c) 2014, Matteo Collina <hello@matteocollina.com>
+Copyright (c) 2014, Matteo Collina <hello@matteocollina.com>
 
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
 
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
- IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
 
 'use strict';
 
 var through = require('through2')
 
 function transform(chunk, enc, cb) {
-  var list      = chunk.toString('utf8').split(this.matcher)
+  var list = chunk.toString('utf8').split(this.matcher)
     , remaining = list.pop()
     , i
 
@@ -57,47 +57,47 @@ function noop(incoming) {
 function split(matcher, mapper, options) {
 
   // Set defaults for any arguments not supplied.
-  matcher = matcher || /\r?\n/;
-  mapper = mapper || noop;
-  options = options || {};
+  matcher = matcher || /\r?\n/
+  mapper = mapper || noop
+  options = options || {}
 
   // Test arguments explicitly.
   switch (arguments.length) {
     case 1:
       // If mapper is only argument.
       if (typeof matcher === 'function') {
-        mapper = matcher;
-        matcher = /\r?\n/;
+        mapper = matcher
+        matcher = /\r?\n/
       }
       // If options is only argument.
       else if (typeof matcher === 'object' && !(matcher instanceof RegExp)) {
-        options = matcher;
-        matcher = /\r?\n/;
+        options = matcher
+        matcher = /\r?\n/
       }
-      break;
+      break
 
     case 2:
       // If mapper and options are arguments.
       if (typeof matcher === 'function') {
-        options = mapper;
-        mapper = matcher;
-        matcher = /\r?\n/;
+        options = mapper
+        mapper = matcher
+        matcher = /\r?\n/
       }
       // If matcher and options are arguments.
       else if (typeof mapper === 'object') {
-        options = mapper;
-        mapper = noop;
+        options = mapper
+        mapper = noop
       }
   }
 
-  var stream = through(options, transform, flush);
+  var stream = through(options, transform, flush)
 
   // this stream is in objectMode only in the readable part
   stream._readableState.objectMode = true;
 
-  stream._last = '';
-  stream.matcher = matcher;
-  stream.mapper = mapper;
+  stream._last = ''
+  stream.matcher = matcher
+  stream.mapper = mapper
 
   return stream
 }

--- a/test.js
+++ b/test.js
@@ -147,3 +147,50 @@ test('has destroy method', function(t) {
 
   input.destroy()
 })
+
+test('support custom matcher and mapper', function(t) {
+  t.plan(2)
+
+  var a = { a: '42' }
+    , b = { b: '24' }
+  var input = split("~", JSON.parse)
+
+  input.pipe(objcb(function(err, list) {
+    t.notOk(err, 'no errors')
+    t.deepEqual(list, [a, b])
+  }))
+
+  input.write(JSON.stringify(a))
+  input.write('~')
+  input.end(JSON.stringify(b))
+})
+
+test('support custom matcher and options', function(t) {
+  t.plan(2)
+
+  var input = split("~", { highWatermark: 2 })
+
+  input.pipe(strcb(function(err, list) {
+    t.notOk(err, 'no errors')
+    t.deepEqual(list, ['hello', 'world'])
+  }))
+
+  input.end('hello~world')
+})
+
+test('support mapper and options', function(t) {
+  t.plan(2)
+
+  var a = { a: '42' }
+    , b = { b: '24' }
+  var input = split(JSON.parse, { highWaterMark: 2 })
+
+  input.pipe(objcb(function(err, list) {
+    t.notOk(err, 'no errors')
+    t.deepEqual(list, [a, b])
+  }))
+
+  input.write(JSON.stringify(a))
+  input.write('\n')
+  input.end(JSON.stringify(b))
+})

--- a/test.js
+++ b/test.js
@@ -72,7 +72,7 @@ test('split using a custom regexp matcher', function(t) {
 test('support an option argument', function(t) {
   t.plan(2)
 
-  var input = split({ highWatermark: 2 })
+  var input = split({ highWaterMark: 2 })
 
   input.pipe(strcb(function(err, list) {
     t.notOk(err, 'no errors')
@@ -149,11 +149,14 @@ test('has destroy method', function(t) {
 })
 
 test('support custom matcher and mapper', function(t) {
-  t.plan(2)
+  t.plan(4)
 
   var a = { a: '42' }
     , b = { b: '24' }
-  var input = split("~", JSON.parse)
+  var input = split('~', JSON.parse)
+
+  t.equal(input.matcher, '~')
+  t.equal(typeof input.mapper, 'function')
 
   input.pipe(objcb(function(err, list) {
     t.notOk(err, 'no errors')
@@ -166,9 +169,14 @@ test('support custom matcher and mapper', function(t) {
 })
 
 test('support custom matcher and options', function(t) {
-  t.plan(2)
+  t.plan(6)
 
-  var input = split("~", { highWatermark: 2 })
+  var input = split('~', { highWaterMark: 1024 })
+
+  t.equal(input.matcher, '~')
+  t.equal(typeof input.mapper, 'function')
+  t.equal(input._readableState.highWaterMark, 1024)
+  t.equal(input._writableState.highWaterMark, 1024)
 
   input.pipe(strcb(function(err, list) {
     t.notOk(err, 'no errors')
@@ -179,11 +187,16 @@ test('support custom matcher and options', function(t) {
 })
 
 test('support mapper and options', function(t) {
-  t.plan(2)
+  t.plan(6)
 
   var a = { a: '42' }
     , b = { b: '24' }
-  var input = split(JSON.parse, { highWaterMark: 2 })
+  var input = split(JSON.parse, { highWaterMark: 1024 })
+
+  t.ok(input.matcher instanceof RegExp, 'matcher is RegExp')
+  t.equal(typeof input.mapper, 'function')
+  t.equal(input._readableState.highWaterMark, 1024)
+  t.equal(input._writableState.highWaterMark, 1024)
 
   input.pipe(objcb(function(err, list) {
     t.notOk(err, 'no errors')


### PR DESCRIPTION
… two arguments are passed.

Hi Matteo,

Thank you for contributing the split2 module! I am using it to parse large newline delimited json files and insert them into a MongoDB database.

I have made some changes to the split() function to explicitly test for the arguments passed. I would like to be able to pass two arguments to split() and have it work correctly. For example, with the original code, the following will not work:

```javascript
var fs = require('fs');
var split2 = require('split2');
var reader = fs.createReadStream('./in.json');
var writer = fs.createWriteStream('./out.json');

reader.pipe(split2(JSON.parse, { highWaterMark: 65535 })).pipe(writer);
```

In this example, I want to use the default matcher and supply a mapper and options. However, with the original code the options are lost. Also, this will not work:

```javascript
reader.pipe(split2("\n", { highWaterMark: 65535 })).pipe(writer);
```

In the above, I want to supply a matcher and options but use the default mapper. Doing this causes an error:

```javascript
    push(this, this.mapper((this._last + list.shift())))
                    ^
TypeError: this.mapper is not a function
    at DestroyableTransform.transform [as _transform] (/home/jeff/WebstormProjects/Streams/node_modules/split2/index.js:27:21)
    at DestroyableTransform.Transform._read (/home/jeff/WebstormProjects/Streams/node_modules/split2/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:10)
    at DestroyableTransform.Transform._write (/home/jeff/WebstormProjects/Streams/node_modules/split2/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:160:12)
    at doWrite (/home/jeff/WebstormProjects/Streams/node_modules/split2/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:333:12)
    at writeOrBuffer (/home/jeff/WebstormProjects/Streams/node_modules/split2/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:319:5)
    at DestroyableTransform.Writable.write (/home/jeff/WebstormProjects/Streams/node_modules/split2/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:246:11)
    at ReadStream.ondata (_stream_readable.js:528:20)
    at emitOne (events.js:77:13)
    at ReadStream.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
```

I can get around this by supplying all three arguments in both cases:

```javascript
reader.pipe(split2(/\r?\n/, JSON.parse, { highWaterMark: 65535 })).pipe(writer);
```
OR
```javascript
reader.pipe(split2("\n", null, { highWaterMark: 65535 })).pipe(writer);
```

However, I thought it would be nice for the split() function to recognize when two arguments are passed and do this automatically. Let me know what you think.

Thanks again!
--jeff