### PR TITLE
add .maxLength option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ is directly passed as a
 [Transform](http://nodejs.org/api/stream.html#stream_class_stream_transform_1)
 option.
 
+Additionally, the `.maxLength` option is implemented, which will make the split stream throw an error
+if the buffer size exceeds `.maxLength`.
+
 Calling `.destroy` will make the stream emit `close`. Use this to perform cleanup logic
 
 ``` js

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ var StringDecoder = require('string_decoder').StringDecoder
 
 function transform (chunk, enc, cb) {
   this._last += this._decoder.write(chunk)
+  if (this._last.length > this.maxLength) {
+    return cb(new Error('maximum buffer reached'))
+  }
 
   var list = this._last.split(this.matcher)
 
@@ -96,6 +99,7 @@ function split (matcher, mapper, options) {
   stream._decoder = new StringDecoder('utf8')
   stream.matcher = matcher
   stream.mapper = mapper
+  stream.maxLength = options.maxLength
 
   return stream
 }

--- a/test.js
+++ b/test.js
@@ -283,3 +283,16 @@ test('truncated utf-8 char', function (t) {
   input.write(buf.slice(0, 3))
   input.end(buf.slice(3, 4))
 })
+
+test('maximum buffer limit', function (t) {
+  t.plan(1)
+
+  var input = split({ maxLength: 2 })
+
+  input.pipe(strcb(function (err, list) {
+    t.ok(err)
+  }))
+
+  input.write('hey')
+})
+


### PR DESCRIPTION
adapted from dominic's split module, this option is useful if you want to guard yourself against too large inputs.