### PR TITLE
chore: bump readable-stream to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tap": "^12.0.0"
   },
   "dependencies": {
-    "readable-stream": "^3.0.0"
+    "readable-stream": "^3.2.0"
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
Isn't that Greenkeeper's job, actually?