### PR TITLE
Don't modify the options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ function split (matcher, mapper, options) {
       }
   }
 
+  options = Object.assign({}, options)
   options.transform = transform
   options.flush = flush
   options.readableObjectMode = true

--- a/test.js
+++ b/test.js
@@ -347,3 +347,17 @@ test('maximum buffer limit w/skip', function (t) {
   input.write('789\nb\nc')
   input.end()
 })
+
+test("don't modify the options object", function (t) {
+  t.plan(2)
+
+  var options = {}
+  var input = split(options)
+
+  input.pipe(strcb(function (err, list) {
+    t.error(err)
+    t.same(options, {})
+  }))
+
+  input.end()
+})


### PR DESCRIPTION
I want to use split2 in pipelines where I can pass each transform the
same options object, e.g.

    class MyTransform extends Transform {
        _transform (chunk, encoding, callback) {
	    // ...
        }
    }
    var options = { highWaterMark: 1024 }
    pump(split2(options), new MyTransform(options), process.stdout)

If split2 adds `transform` and `flush` properties to `options`, then
`MyTransform` will also set those options, and it won't behave as
expected.

To avoid this, we can use a shallow copy of `options` instead of
operating on the object directly.