### PR TITLE
Implement keepMatcher feature to retain matcher characters at end of each line

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,21 @@ is directly passed as a
 [Transform](https://nodejs.org/api/stream.html#stream_new_stream_transform_options)
 option.
 
-Additionally, the `.maxLength` and `.skipOverflow` options are implemented, which set limits on the internal
-buffer size and the stream's behavior when the limit is exceeded. There is no limit unless `maxLength` is set. When
-the internal buffer size exceeds `maxLength`, the stream emits an error by default. You may also set `skipOverflow` to
-true to suppress the error and instead skip past any lines that cause the internal buffer to exceed `maxLength`.
+Additionally, the `.maxLength`, `.skipOverflow` and `keepMatcher` options are implemented, which set limits on the internal
+buffer size, the stream's behavior when the limit is exceeded and whether to keep the line matcher characters at the end of 
+each line. There is no limit unless `maxLength` is set. When the internal buffer size exceeds `maxLength`, the stream emits an 
+error by default. You may also set `skipOverflow` to true to suppress the error and instead skip past any lines that cause the
+internal buffer to exceed `maxLength`. By default, line matchers are thrown away. If you set keepMatcher to true, trailing
+matcher characters at the end of the line are retained. You will also need to split by a regular expression with a matching 
+group as illustrated below.
+
+```js
+  fs.createReadStream(file)
+    .pipe(split(/(\r?\n)/,{keepMatcher:true}))
+    .on('data', function (line) {
+      //each chunk now is a separate line, and retains the \r\n or \n at the end!
+    })
+```
 
 Calling `.destroy` will make the stream emit `close`. Use this to perform cleanup logic
 

--- a/index.js
+++ b/index.js
@@ -35,12 +35,19 @@ function transform (chunk, enc, cb) {
   } else {
     this[kLast] += this[kDecoder].write(chunk)
     list = this[kLast].split(this.matcher)
+
+    if (this.keepMatcher) {
+      let l = []
+      list.length % 2 && list.push('') // Add trailing empty string if odd elements
+      for (var i = 0; i < list.length; i += 2) push(l, list[i] + list[i + 1])
+      list = l
+    }
   }
 
   this[kLast] = list.pop()
 
-  for (var i = 0; i < list.length; i++) {
-    push(this, this.mapper(list[i]))
+  for (var j = 0; j < list.length; j++) {
+    push(this, this.mapper(list[j]))
   }
 
   this.overflow = this[kLast].length > this.maxLength
@@ -116,6 +123,7 @@ function split (matcher, mapper, options) {
   stream.mapper = mapper
   stream.maxLength = options.maxLength
   stream.skipOverflow = options.skipOverflow
+  stream.keepMatcher = options.keepMatcher
   stream.overflow = false
 
   return stream

--- a/test.js
+++ b/test.js
@@ -361,3 +361,19 @@ test("don't modify the options object", function (t) {
 
   input.end()
 })
+
+test('keep newlines when using keepDelimiter option', function (t) {
+  t.plan(3)
+
+  var options = { keepMatcher: true }
+  var input = split(/(\n)/, options)
+
+  input.pipe(strcb(function (err, list) {
+    t.error(err)
+    t.equal(list[0], 'a line including terminating newline\n')
+    t.equal(list[1], 'and the next without a newline')
+  }))
+
+  input.write('a line including terminating newline\nand the next without a newline')
+  input.end()
+})


### PR DESCRIPTION
Hi @mcollina 

Just submitting a feature PR.  

The PR implements a `keepMatcher` option that will retain the matching characters at the end of each line of input.

Tests have been included, and the README has been updated to explain the API addition.

Feedback, or changes welcome.

Cheers,
Damo.