### PR TITLE
Option to allow for async transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ function transform (chunk, enc, cb) {
   this.overflow = this[kLast].length > this.maxLength
   if (this.overflow && !this.skipOverflow) return cb(new Error('maximum buffer reached'))
 
-  cb()
+  if(this.asyncTransform) {
+    setImmediate(cb)
+  } else {
+    cb()
+  }
 }
 
 function flush (cb) {
@@ -124,6 +128,7 @@ function split (matcher, mapper, options) {
   stream.mapper = mapper
   stream.maxLength = options.maxLength
   stream.skipOverflow = options.skipOverflow
+  stream.asyncTransform = options.asyncTransform
   stream.overflow = false
 
   return stream

--- a/test.js
+++ b/test.js
@@ -390,3 +390,24 @@ test('mapper throws on transform', function (t) {
   input.write('\n')
   input.end('b')
 })
+
+test('async transform', function (t) {
+  t.plan(3)
+
+  var input = split({ asyncTransform: true })
+
+  let asyncCalled = false
+  setTimeout(() => {
+    asyncCalled = true
+  }, 0);
+
+  input.pipe(strcb(function (err, list) {
+    t.error(err)
+    t.deepEqual(list, ['helloworld'])
+    t.true(asyncCalled)
+  }))
+
+  input.write('hello')
+  input.write('world')
+  input.end()
+})


### PR DESCRIPTION
I would like to propose a small feature to allow for async transform. In my use case, I have a very large buffer to decode and I would like to avoid blocking the event loop if possible. This minor adjustment allows each chunk to be decoded in a separate phase such that other pending events can be processed in each chunk. 

If this feature is acceptable to you, I would update the documentation to describe this use case as well.

Thank you so much for your time. This little library solves a lot of my problems.