### PR TITLE
build: indicate v12 is min node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "http://github.com/mcollina/split2/issues"
   },
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "ISC",


### PR DESCRIPTION
v4 of library indicates Node 12 as requirement, but engines field was not updated.