### PR TITLE
doc: Fix error in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fs.createReadStream(file)
   .on('data', function (obj) {
     //each chunk now is a js object
   })
-  .on("error", function(error) => {
+  .on("error", function(error) {
     //handling parsing errors
   })
 ```


### PR DESCRIPTION
The readme sample code for NDJSON contained an error.
It was a mixture between arrow function syntax and keyword function syntax.
I removed the erroneous character to make the code correct.