### PR TITLE
Add support for Symbol.split

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function split (matcher, mapper, options) {
         mapper = matcher
         matcher = /\r?\n/
       // If options is only argument.
-      } else if (typeof matcher === 'object' && !(matcher instanceof RegExp)) {
+      } else if (typeof matcher === 'object' && !(matcher instanceof RegExp) && !matcher[Symbol.split]) {
         options = matcher
         matcher = /\r?\n/
       }

--- a/test.js
+++ b/test.js
@@ -390,3 +390,20 @@ test('mapper throws on transform', function (t) {
   input.write('\n')
   input.end('b')
 })
+
+test('supports Symbol.split', function (t) {
+  t.plan(2)
+
+  const input = split({
+    [Symbol.split] (str) {
+      return str.split('~')
+    }
+  })
+
+  input.pipe(strcb(function (err, list) {
+    t.error(err)
+    t.deepEqual(list, ['hello', 'world'])
+  }))
+
+  input.end('hello~world')
+})


### PR DESCRIPTION
The readme says that split2 takes the same arguments as String.split, but it was missing support for objects with the [Symbol.split](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) property.

This has been supported since Node 6, which is far below `engines.node`.